### PR TITLE
Added more options to process_zarr.py.

### DIFF
--- a/process_zarr.py
+++ b/process_zarr.py
@@ -1,16 +1,19 @@
 ##necessary libraries
 import argparse
+import os
 import zarr
 import numpy as np
 import json
 import pandas as pd
 import xarray as xr
-from datetime import datetime
-from netCDF4 import Dataset
+import dask
+from dask.distributed import Client, LocalCluster
 
 
 def find_closest_index(array, target):
-    """Finds the indices of the closest values to target in array, supporting datetime and numeric values."""
+    """
+    Finds the indices of the closest values to target in array, supporting datetime and numeric values.
+    """
     if isinstance(array, (pd.Series, pd.Index)):
         array = array.to_numpy()
     
@@ -33,7 +36,9 @@ def find_closest_index(array, target):
 
 
 def get_variable_attrs(vardic, igroup, invarname):
-    """Fetch variable attributes based on `igroup`."""
+    """
+    Fetch variable attributes based on `igroup`.
+    """
     if igroup == 'ScalarState':
         iunits = vardic['ScalarState_units'][invarname]
         lname = vardic['ScalarState_long_names'][invarname]
@@ -48,70 +53,204 @@ def get_variable_attrs(vardic, igroup, invarname):
     
     return iunits, lname
 
+def extract_3dvar(data_dict):
+    """
+    Extract a 3D variable from zarr and write to a netCDF file.
 
-def process_zarr_to_netcdf(indir, infile, outdir, igroup, invarname, z_values, freq='1h'):
-    zin = zarr.open((indir + '/' + infile), "r")
+    Args:
+        data_dict: dictionary
+            A dictionary containing all inputs.
+    
+    Returns:
+        outfile: string
+            Output filename.
+    """
+    # Get variables from dictionary
+    tt = data_dict['tt']
+    time_in = data_dict['time_in']
+    zin = data_dict['zin']
+    outdir = data_dict['outdir']
+    invarname = data_dict['data_dict']
+    igroup = data_dict['igroup']
+    varindx = data_dict['varindx']
+    z_values = data_dict['z_values']
+    iunits = data_dict['iunits']
+    lname = data_dict['lname']
 
-    time = zin["datetime"][:]
+    # Get coordinate variables
     X = zin["X"][:]
     Y = zin["Y"][:]
     Z = zin["Z"][:]
     if invarname == "w":
         Z = zin["Z_edge"][:]
-        
+
+    # Find closest Z indices from input
+    if z_values is not None:
+        iz_range = find_closest_index(Z, np.array(z_values))
+    else:
+        # Make full Z indices
+        iz_range = np.arange(0, len(Z), 1)
+
+    # Create output filename
+    time_value = time_in
+    time_str = str(time_value).replace(":", "-").replace(" ", "_").split(".")[0]
+    outtime = f"{time_str}"
+    outfile = f"{outdir}/{invarname}_{outtime}.nc"
+
+    # # Check if the file already exists
+    # if os.path.exists(outfile):
+    #     print(f"Skipping existing file: {outfile}")
+    #     continue
+
+    # Get 3D variable
+    outvar = np.expand_dims(zin[igroup][int(tt), varindx, :, :, iz_range], axis=0)
+
+    # Make output Xarray DataSet
+    ds_out = xr.Dataset(
+        {invarname: (["time", "X", "Y", "Z"], outvar)},
+        coords={
+            "time": (["time"], np.array([time_in], dtype='object')),
+            "X": (["X"], X),
+            "Y": (["Y"], Y),
+            "Z": (["Z"], Z[iz_range])
+        },
+        attrs={"units": ("units", iunits), "long_name": ("long_name", lname)}
+    )
+
+    # print(f"Writing: {outfile}")
+    ds_out.to_netcdf(path=outfile, mode='w', format='NETCDF4', unlimited_dims='time')
+    ds_out.close()
+    print(f"Saved: {outfile}")
+    del ds_out
+    return outfile
+
+
+def process_zarr_to_netcdf(indir, infile, outdir, igroup, invarname, 
+                           z_values=None, freq=None,
+                           start_time=None, end_time=None,
+                           run_parallel=0, n_workers=1):
+    """
+    Extract a variable from zarr and write to netCDF files.
+
+    Args:
+        indir: string
+            Zarr data input directory.
+        infile: string
+            Zarr data input filename.
+        outdir: string
+            Output netCDF file directory.
+        igroup: string
+            Name of the group for the variable.
+        invarname: string
+            Desired variable name.
+        z_values: array-like, optional, default=None
+            Vertical levels to extract the variable.
+        freq: string, optional, default=None
+            Temporal frequency to extract the variable.
+        start_time: string, optional, default=None
+            Start datetime to process ('yyyy-mo-dyThh:mm:ss').
+        end_time: string, optional, default=None
+            End datetime to process ('yyyy-mo-dyThh:mm:ss').
+        run_parallel: int, optional, default=0
+            Flag to run processing in parallel.
+        n_workers: int, optional, default=1
+            Number of workers to run in parallel.
+
+    Returns:
+        None.
+    """
+    # Open zarr file
+    zin = zarr.open((indir + '/' + infile), "r")
+    # Get coordinate variables
+    time_in = zin["datetime"][:]
+    
+    # Read zarr file attributes
     with open((indir + '/' + infile + '/.zattrs')) as fp:
         vardic = json.load(fp)
 
+    # Get variable attributes
     iunits, lname = get_variable_attrs(vardic, igroup, invarname)    
     
-    ini_time = time[0]
-    end_time = time[-1]
-
+    # Get variable index from attribute
     varindx = zin.attrs[igroup + "_variable_index_map"][invarname]
-    iz_range = find_closest_index(Z, np.array(z_values))
-    time_steps = pd.date_range(start=ini_time, end=end_time, freq=freq)
-    it_time = find_closest_index(time, time_steps)
 
-    for i in it_time:
-        time_value = time[i]
-        time_str = str(time_value).replace(":", "-").replace(" ", "_").split(".")[0]
-        outtime = f"test_{invarname}_{time_str}"
-        outfile = outdir + f"/test_{invarname}_{outtime}.nc"
+    # Find closest time indices from input
+    if freq is not None:
+        time0 = time_in[0]
+        time1 = time_in[-1]
+        time_steps = pd.date_range(start=time0, end=time1, freq=freq)
+        it_time = find_closest_index(time_in, time_steps)
+    else:
+        # Make full time indices
+        it_time = np.arange(0, len(time_in), 1)
 
-        # Check if the file already exists
-        if os.path.exists(outfile):
-            print(f"Skipping existing file: {outfile}")
-            continue
+    # Find times within input range
+    if (start_time is not None) & (end_time is not None):
+        # Convert to Pandas Datetime
+        _start_time = pd.to_datetime(start_time)
+        _end_time = pd.to_datetime(end_time)
+        # Convert to Pandas DatetimeIndex
+        _time_in = pd.DatetimeIndex(time_in)
+        # Find time indices within the input range
+        it_time = np.where((_time_in >= _start_time) & (_time_in <= _end_time))[0]
 
-        outvar = np.expand_dims(zin[igroup][int(i), varindx, :, :, iz_range], axis=0)
+    # Check number of times
+    if len(it_time) > 0:
 
-        ds_out = xr.Dataset(
-            {invarname: (["time", "X", "Y", "Z"], outvar)},
-            coords={
-                "time": (["time"], np.array([time[i]], dtype='object')),
-                "X": (["X"], X),
-                "Y": (["Y"], Y),
-                "Z": (["Z"], Z[iz_range])
-            },
-            attrs={"units": ("units", iunits), "long_name": ("long_name", lname)}
-        )
+        # Initialize dask for parallel
+        if run_parallel == 1:
+            cluster = LocalCluster(n_workers=n_workers, threads_per_worker=1)
+            client = Client(cluster)
 
-        print("Writing: " + outfile)
-        ds_out.to_netcdf(path=outfile, mode='w', format='NETCDF4', unlimited_dims='time')
-        ds_out.close()
-        del ds_out
+        results = []
+
+        # Iterate over time
+        for tt in it_time:
+            # Put variables in a dictionary
+            data_dict = {}
+            data_dict['tt'] = tt
+            data_dict['time_in'] = time_in[tt]
+            data_dict['zin'] = zin
+            data_dict['outdir'] = outdir
+            data_dict['data_dict'] = invarname
+            data_dict['igroup'] = igroup
+            data_dict['varindx'] = varindx
+            data_dict['z_values'] = z_values
+            data_dict['iunits'] = iunits
+            data_dict['lname'] = lname
+            # Call extract function
+            if run_parallel == 0:
+                result = extract_3dvar(data_dict)
+            elif run_parallel == 1:
+                result = dask.delayed(extract_3dvar)(data_dict)
+            results.append(result)
+
+        # Execute parallel computation
+        if run_parallel == 1:
+            final_result = dask.compute(*results)
+
+    else:
+        print(f"No times found between {start_time} and {end_time}")
+
 
 
 if __name__ == "__main__":
+    # Define and retrieve the command-line arguments...
     parser = argparse.ArgumentParser(description='Process Zarr to NetCDF.')
     parser.add_argument('--indir', type=str, required=True, help='Input directory containing the Zarr files.')
     parser.add_argument('--infile', type=str, required=True, help='Input Zarr filename.')
     parser.add_argument('--outdir', type=str, required=True, help='Output directory for NetCDF files.')
     parser.add_argument('--igroup', type=str, required=True, help='Group name in Zarr file.')
     parser.add_argument('--invarname', type=str, required=True, help='Variable name in Zarr file.')
-    parser.add_argument('--z_values', type=float, nargs='+', required=True, help='Z values for the levels to extract.')
-    parser.add_argument('--freq', type=str, default='1h', help='Frequency of the output time steps (e.g., 1h, 3h, 6h, 30min).')
-
+    parser.add_argument('--z_values', type=float, nargs='+', default=None, help='Z values for the levels to extract.')
+    parser.add_argument('--freq', type=str, default=None, help='Frequency of the output time steps (e.g., 1h, 3h, 6h, 30min).')
+    parser.add_argument('--s_time', type=str, default=None, help='Start datetime to process (yyyy-mo-dyThh:mm:ss).')
+    parser.add_argument('--e_time', type=str, default=None, help='End datetime to process (yyyy-mo-dyThh:mm:ss).')
+    parser.add_argument("--parallel", help="Flag to run in parallel (0:serial, 1:parallel)", type=int, default=0)
+    parser.add_argument("--n_workers", help="Number of workers to run in parallel", type=int, default=1)
     args = parser.parse_args()
 
-    process_zarr_to_netcdf(args.indir, args.infile, args.outdir, args.igroup, args.invarname, args.z_values, args.freq)
+    process_zarr_to_netcdf(args.indir, args.infile, args.outdir, args.igroup, args.invarname, 
+                           z_values=args.z_values, freq=args.freq,
+                           start_time=args.s_time, end_time=args.e_time,
+                           run_parallel=args.parallel, n_workers=args.n_workers)

--- a/run_process_zarr.sh
+++ b/run_process_zarr.sh
@@ -11,8 +11,8 @@ IGROUP="DiagnosticState"
 INVARNAME="thetav" # for more info about available variables visit https://portal.nersc.gov/cfs/m1867/pinacles_docs/site/fields_zarr/ 
 
 # Output directory for NetCDF files
-# OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
-OUTDIR="/pscratch/sd/f/feng045/PINACLES/rce/1km/fields3d/${INVARNAME}"
+OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
+# OUTDIR="/pscratch/sd/f/feng045/PINACLES/rce/1km/fields3d/${INVARNAME}"
 
 # Create the output directory if it does not exist
 mkdir -p "$OUTDIR"
@@ -29,17 +29,17 @@ else
 fi
 
 ## Set parallel options
-run_parallel=1  # 0: serial, 1: parallel
+run_parallel=0  # 0: serial, 1: parallel
 n_workers=32  # number of workers (CPU in a node)
 
 ## Optional input parameters
 # Vertical levels
-Z_VALUES=(100 500 1000 1500 3000 4500 5500 7500 9500 10500 12000 )
+Z_VALUES=(100 300 500 700 900 1100 1300 1500 1700 1900 2100 2300 2500 2700 2900 3100 3300 3500 3700 3900 4100 4300 4500 4700 4900 5100 )
 # Temporal frequency: '1h', '3h', '6h', '30min',etc
-FREQ="10min"
+FREQ="12h"
 # Time period (format: 'yyyy-mo-dyThh:mm:ss')
-start_time='2000-01-07T00'
-end_time='2000-01-09T23'
+start_time='2000-02-20T00:00:00'
+end_time='2000-02-25T00:00:00'
 
 # Loop over each subdirectory in the parent directory
 for SUBDIR in "$PARENT_DIR"/test_1km_01_started_*/; do

--- a/run_process_zarr.sh
+++ b/run_process_zarr.sh
@@ -6,11 +6,13 @@
 PARENT_DIR="/pscratch/sd/w/wcmca1/PINACLES/rce/1km/run/"
 
 # Parameters for processing
-IGROUP="ScalarState" # options are "ScalarState", "VelocityState" and "Diagnos"
-INVARNAME="qv" # for more info about available variables visit https://portal.nersc.gov/cfs/m1867/pinacles_docs/site/fields_zarr/ 
+# IGROUP="ScalarState" # options are "ScalarState", "VelocityState" and "Diagnos"
+IGROUP="DiagnosticState"
+INVARNAME="thetav" # for more info about available variables visit https://portal.nersc.gov/cfs/m1867/pinacles_docs/site/fields_zarr/ 
 
 # Output directory for NetCDF files
-OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
+# OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
+OUTDIR="/pscratch/sd/f/feng045/PINACLES/rce/1km/fields3d/${INVARNAME}"
 
 # Create the output directory if it does not exist
 mkdir -p "$OUTDIR"
@@ -26,10 +28,18 @@ else
     echo "Output directory is ready: $OUTDIR"
 fi
 
+## Set parallel options
+run_parallel=1  # 0: serial, 1: parallel
+n_workers=32  # number of workers (CPU in a node)
 
-## Input parameters
+## Optional input parameters
+# Vertical levels
 Z_VALUES=(100 500 1000 1500 3000 4500 5500 7500 9500 10500 12000 )
-FREQ="1h"  # Change this to desired frequency: '1h', '3h', '6h', '30min',etc
+# Temporal frequency: '1h', '3h', '6h', '30min',etc
+FREQ="10min"
+# Time period (format: 'yyyy-mo-dyThh:mm:ss')
+start_time='2000-01-07T00'
+end_time='2000-01-09T23'
 
 # Loop over each subdirectory in the parent directory
 for SUBDIR in "$PARENT_DIR"/test_1km_01_started_*/; do
@@ -38,7 +48,10 @@ for SUBDIR in "$PARENT_DIR"/test_1km_01_started_*/; do
     
     echo "Starting processing for directory: $SUBDIR"
   
-    python process_zarr.py --indir "$SUBDIR" --infile "$INFILE" --outdir "$OUTDIR" --igroup "$IGROUP" --invarname "$INVARNAME" --z_values "${Z_VALUES[@]}" --freq "$FREQ"
+    python process_zarr.py --indir "$SUBDIR" --infile "$INFILE" --outdir "$OUTDIR" --igroup "$IGROUP" --invarname "$INVARNAME" \
+        --z_values "${Z_VALUES[@]}" --freq ${FREQ} \
+        --s_time ${start_time} --e_time ${end_time} \
+        --parallel ${run_parallel} --n_workers ${n_workers}
     
     
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
1. Added these optional inputs to process_zarr.py for more flexibility:
- --s_time: Start datetime to process. Default will process all available times.
- --e_time: End datetime to process. Default will process all available times.
- --z_values: Z values for vertical levels to extract. Default will process all levels.
- --freq: Frequency of the output time steps. Default will process all times.
- --parallel: Flag to run in parallel. Default runs in serial.
- --n_workers: Number of workers to run in parallel.

2. Updated run_process_zarr.sh to include examples of the optional inputs.