### PR TITLE
Fixed output frequency and reference time.

### DIFF
--- a/process_zarr.py
+++ b/process_zarr.py
@@ -184,6 +184,7 @@ def process_zarr_to_netcdf(
     zin = zarr.open((indir + '/' + infile), "r")
     # Get coordinate variables
     time_in = zin["datetime"][:]
+    _time_in = pd.DatetimeIndex(time_in)
     
     # Read zarr file attributes
     with open((indir + '/' + infile + '/.zattrs')) as fp:
@@ -195,33 +196,9 @@ def process_zarr_to_netcdf(
     # Get variable index from attribute
     varindx = zin.attrs[igroup + "_variable_index_map"][invarname]
 
-    # # If start_time and end_time are provided, convert to Pandas Datetime
-    # if (start_time is not None) & (end_time is not None):
-    #     _start_time = pd.to_datetime(start_time)
-    #     _end_time = pd.to_datetime(end_time)
-    #     _time_in = pd.DatetimeIndex(time_in)
-    
-    # # Find closest time indices from input considering frequency and range
-    # if freq is not None:
-    #     if (start_time is not None) & (end_time is not None):
-    #         time_steps = pd.date_range(start=_start_time, end=_end_time, freq=freq)
-    #         it_time = find_closest_index(_time_in, time_steps)
-    #     else:
-    #         time0 = time_in[0]
-    #         time1 = time_in[-1]
-    #         time_steps = pd.date_range(start=time0, end=time1, freq=freq)
-    #         it_time = find_closest_index(time_in, time_steps)
-    # else:
-    #     # Make full time indices
-    #     if (start_time is not None) & (end_time is not None):
-    #         it_time = np.where((_time_in >= _start_time) & (_time_in <= _end_time))[0]
-    #     else:
-    #         it_time = np.arange(len(time_in))
-
-
     # Find closest time indices from input
     if freq is not None:
-        time0 = time_in[0]
+        time0 = pd.to_datetime(ref_time) #time_in[0]
         time1 = time_in[-1]
         time_steps = pd.date_range(start=time0, end=time1, freq=freq)
         it_time = find_closest_index(time_in, time_steps)
@@ -242,6 +219,7 @@ def process_zarr_to_netcdf(
         time_out = _time_in[(_time_in >= _start_time) & (_time_in <= _end_time)]
         # Find indices in time_in that match time_out
         it_time = pd.DatetimeIndex(time_in).get_indexer(time_out)
+    
 
     # Check number of times
     if len(it_time) > 0:

--- a/run_process_zarr.sh
+++ b/run_process_zarr.sh
@@ -8,11 +8,11 @@ PARENT_DIR="/pscratch/sd/w/wcmca1/PINACLES/rce/1km/run/"
 # Parameters for processing
 # IGROUP="ScalarState" # options are "ScalarState", "VelocityState" and "Diagnos"
 IGROUP="DiagnosticState"
-INVARNAME="thetav" # for more info about available variables visit https://portal.nersc.gov/cfs/m1867/pinacles_docs/site/fields_zarr/ 
+INVARNAME="buoyancy" # for more info about available variables visit https://portal.nersc.gov/cfs/m1867/pinacles_docs/site/fields_zarr/ 
 
 # Output directory for NetCDF files
-# OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
-OUTDIR="/pscratch/sd/f/feng045/PINACLES/rce/1km/fields3d/${INVARNAME}"
+OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
+# OUTDIR="/pscratch/sd/f/feng045/PINACLES/rce/1km/fields3d/${INVARNAME}"
 
 # Create the output directory if it does not exist
 mkdir -p "$OUTDIR"
@@ -36,16 +36,16 @@ n_workers=32  # number of workers (CPU in a node)
 # Vertical levels
 Z_VALUES=(100 300 500 700 900 1100 1300 1500 1700 1900 2100 2300 2500 2700 2900 3100 3300 3500 3700 3900 4100 4300 4500 4700 4900 5100 )
 # Temporal frequency: '1h', '3h', '6h', '30min',etc
-FREQ="30min"
+FREQ="12h"
 # Time period (format: 'yyyy-mo-dyThh:mm:ss')
-start_time='2000-01-07T00:00:00'
-end_time='2000-01-09T00:00:00'
+start_time='2000-01-25T00:00:00'
+end_time='2000-02-20T00:00:00'
 # start_time='2000-02-20T00:00:00'
 # end_time='2000-02-25T00:00:00'
 
 # Reference time (for output netCDF file time encoding)
 # Default: '2000-01-01T00:00:00'
-ref_time='1970-01-01T00:00:00'  # Epoch time
+ref_time='2000-01-01T00:00:00'  # Epoch time
 
 # Loop over each subdirectory in the parent directory
 for SUBDIR in "$PARENT_DIR"/test_1km_01_started_*/; do

--- a/run_process_zarr.sh
+++ b/run_process_zarr.sh
@@ -11,8 +11,8 @@ IGROUP="DiagnosticState"
 INVARNAME="thetav" # for more info about available variables visit https://portal.nersc.gov/cfs/m1867/pinacles_docs/site/fields_zarr/ 
 
 # Output directory for NetCDF files
-OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
-# OUTDIR="/pscratch/sd/f/feng045/PINACLES/rce/1km/fields3d/${INVARNAME}"
+# OUTDIR="/pscratch/sd/p/paccini/temp/output_pinacles/${INVARNAME}"
+OUTDIR="/pscratch/sd/f/feng045/PINACLES/rce/1km/fields3d/${INVARNAME}"
 
 # Create the output directory if it does not exist
 mkdir -p "$OUTDIR"
@@ -29,17 +29,23 @@ else
 fi
 
 ## Set parallel options
-run_parallel=0  # 0: serial, 1: parallel
+run_parallel=1  # 0: serial, 1: parallel
 n_workers=32  # number of workers (CPU in a node)
 
 ## Optional input parameters
 # Vertical levels
 Z_VALUES=(100 300 500 700 900 1100 1300 1500 1700 1900 2100 2300 2500 2700 2900 3100 3300 3500 3700 3900 4100 4300 4500 4700 4900 5100 )
 # Temporal frequency: '1h', '3h', '6h', '30min',etc
-FREQ="12h"
+FREQ="30min"
 # Time period (format: 'yyyy-mo-dyThh:mm:ss')
-start_time='2000-02-20T00:00:00'
-end_time='2000-02-25T00:00:00'
+start_time='2000-01-07T00:00:00'
+end_time='2000-01-09T00:00:00'
+# start_time='2000-02-20T00:00:00'
+# end_time='2000-02-25T00:00:00'
+
+# Reference time (for output netCDF file time encoding)
+# Default: '2000-01-01T00:00:00'
+ref_time='1970-01-01T00:00:00'  # Epoch time
 
 # Loop over each subdirectory in the parent directory
 for SUBDIR in "$PARENT_DIR"/test_1km_01_started_*/; do
@@ -50,7 +56,7 @@ for SUBDIR in "$PARENT_DIR"/test_1km_01_started_*/; do
   
     python process_zarr.py --indir "$SUBDIR" --infile "$INFILE" --outdir "$OUTDIR" --igroup "$IGROUP" --invarname "$INVARNAME" \
         --z_values "${Z_VALUES[@]}" --freq ${FREQ} \
-        --s_time ${start_time} --e_time ${end_time} \
+        --s_time ${start_time} --e_time ${end_time} --ref_time ${ref_time} \
         --parallel ${run_parallel} --n_workers ${n_workers}
     
     


### PR DESCRIPTION
1. Updated process_zarr.py to:
- Fixed bug where output frequency does not match input.
- Added --ref_time input argument for output netCDF time encoding. Default (not supplied) is ‘2000-01-01T00:00:00’. The time encoding is now ‘seconds since {ref_time}’.

2. Updated run_process_zarr.sh to show example with --ref_time.